### PR TITLE
Add machine wide and user cached options for lookup of shpod.yaml

### DIFF
--- a/shpod.sh
+++ b/shpod.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 # For more information about shpod, check it out on GitHub:
 # https://github.com/bretfisher/shpod
-if [ -f shpod.yaml ]; then
-  YAML=shpod.yaml
-else
-  YAML=https://k8smastery.com/shpod.yaml
-fi
+YAML=https://k8smastery.com/shpod.yaml
+for location in "/etc" "$HOME/.shpod" `pwd` ; do
+  if [ -f "$location/shpod.yaml" ]; then
+    YAML="$location/shpod.yaml"
+  fi
+done
 if [ "$(kubectl get pod --namespace=shpod shpod --ignore-not-found -o jsonpath={.status.phase})" = "Running" ]; then
   echo "Shpod is already running. Starting a new shell with 'kubectl exec'."
   echo "(Note: if the main invocation of shpod exits, all others will be terminated.)"


### PR DESCRIPTION
As it stands, if you run shpod from a directory other than the one which contains shpod.yaml, it won't find the configuration, and will download it from the default location. This PR adds a few extra places that it should look (/etc/shpod.yaml and $HOME/.shpod/shpod.yaml). This allows a user to put shpod.sh in somewhere like $HOME/bin, put their configuration in one of those two locations, and customize as needed.

I'm using this so that I can add extra permissions to cluster roles of the shpods I'm attaching to various Kubernetes clusters I'm accessing.